### PR TITLE
fix layer ID key in get_existing_layer()

### DIFF
--- a/pywwt/client.py
+++ b/pywwt/client.py
@@ -209,7 +209,10 @@ class WWTClient(object):
         Also takes the standard keyword arguments.
         """
         layers = self.get_layer_list()
-        layer_id = layers[name]["ID"]
+        if "id" in layers[name]:
+            layer_id = layers[name]["id"]
+        else:
+            layer_id = layers[name]["ID"]
         fields = []
         return WWTLayer(name, layer_id, fields, self)
 

--- a/pywwt/client.py
+++ b/pywwt/client.py
@@ -209,7 +209,7 @@ class WWTClient(object):
         Also takes the standard keyword arguments.
         """
         layers = self.get_layer_list()
-        layer_id = layers[name]["id"]
+        layer_id = layers[name]["ID"]
         fields = []
         return WWTLayer(name, layer_id, fields, self)
 


### PR DESCRIPTION
Hi,
I've fixed a bug with pywwt on my local copy and you might want to consider including this.

get_existing_layer() failed because the key "id" cannot be found (tested
with WWT version 5.2.9). The correct key should be "ID", as returned by
LCAPI layerlist (http://www.worldwidetelescope.org/Developers/LayerControlAPI#layerlist)

Note:
I'm not sure whether this behaviour changed at some point or was case-insensitive at some point. I don't have an old version available.
